### PR TITLE
Update doctr deploy usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
 script:
   - pip install sphinx doctr ipython
   - make html
-  - doctr deploy --built-docs '_build/html' --gh-pages-docs .
+  - doctr deploy --built-docs '_build/html' .


### PR DESCRIPTION
Hi! I know the repo is deprecated and so this _probably_ doesn't matter, but just in case, we made a backwards-incompatible change to how `doctr deploy` works and while it will continue to work for now in the old way we're deprecating the flag and will remove it in the next major release.

Deploy directory is now a required argument and `--gh-pages-docs` flag is deprecated